### PR TITLE
Fix card visibility and initialization

### DIFF
--- a/Assets/Scripts/GameEntryPoint.cs
+++ b/Assets/Scripts/GameEntryPoint.cs
@@ -100,6 +100,11 @@ public class GameEntryPoint : MonoBehaviour
 
         _inventoryModel.OnSelectionChanged += UpdateToolbarAndStats;
 
+        if (!_inventoryModel.SelectedItems.Any() && _inventoryModel.Items.OfType<CardModel>().Any())
+        {
+            var firstCard = _inventoryModel.Items.OfType<CardModel>().First();
+            _inventoryModel.ToggleSelection(firstCard);
+        }
 
         UpdateToolbarAndStats();
 
@@ -138,6 +143,7 @@ public class GameEntryPoint : MonoBehaviour
             instance.Init(card, _inventoryPresenter, isToolbar: true);
             var cardView = instance.GetComponent<CardView>();
             new CardPresenter().Init(card, cardView);
+            instance.OnDroppedInContainer(true);
         }
     }
 
@@ -164,5 +170,7 @@ public class GameEntryPoint : MonoBehaviour
         _statsPresenter.Init(toolbarCards, totalCardStatsView);
 
         InitUISelectedCardsToolbar(toolbarCards);
+
+        _bossModel.GetUpdatedStats(_zoneModel.CurrentZone);
     }
 }

--- a/Assets/Scripts/Presentation/Entity/EntityView.cs
+++ b/Assets/Scripts/Presentation/Entity/EntityView.cs
@@ -184,12 +184,12 @@ namespace Presentation.Entity
             {
                 view.Slider.gameObject.SetActive(true);
                 view.Level.gameObject.SetActive(true);
-                view.Rank.gameObject.SetActive(true);
+                view.Rank.gameObject.SetActive(false);
+                view.CountText.gameObject.SetActive(false);
                 view.ExpCurrent.gameObject.SetActive(true);
                 view.ExpToNextLevel.gameObject.SetActive(true);
 
                 view.SetLevel(_cardModel.Level.Value);
-                view.SetRank(_cardModel.Rank.Value);
                 view.SetSliderNextExp(_cardModel.ExpToNextLevel.Value);
                 view.SetSliderCurrentExp(_cardModel.ExpCurrent.Value);
                 view.SetTextNextExp(_cardModel.ExpToNextLevel.Value);
@@ -199,12 +199,13 @@ namespace Presentation.Entity
             {
                 view.Slider.gameObject.SetActive(false);
                 view.Level.gameObject.SetActive(false);
-                view.Rank.gameObject.SetActive(false);
+                view.Rank.gameObject.SetActive(true);
                 view.ExpCurrent.gameObject.SetActive(false);
                 view.ExpToNextLevel.gameObject.SetActive(false);
 
                 view.CountText.gameObject.SetActive(true);
                 view.SetCount(_cardModel.Count.Value);
+                view.SetRank(_cardModel.Rank.Value);
             }
         }
     }

--- a/Assets/Scripts/Presentation/Inventory/InventoryPresenter.cs
+++ b/Assets/Scripts/Presentation/Inventory/InventoryPresenter.cs
@@ -34,7 +34,9 @@ namespace Presentation.Inventory
             {
                 var slot = _view.SpawnItemView();
                 slot.Init(card, this, isToolbar: false);
-                new CardPresenter().Init(card, slot.GetComponent<CardView>());
+                var view = slot.GetComponent<CardView>();
+                new CardPresenter().Init(card, view);
+                slot.OnDroppedInContainer(false);
             }
         }
         


### PR DESCRIPTION
## Summary
- adjust `EntityView` to hide rank and count on toolbar
- ensure inventory items use correct UI state
- spawn toolbar cards with current XP values and add a default selection
- restore boss HP when toolbar cards change

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401e95cc388329aa8e7e753587e801