### PR TITLE
Allow cards to reach level 100

### DIFF
--- a/Assets/Scripts/Battle/BattleScript.cs
+++ b/Assets/Scripts/Battle/BattleScript.cs
@@ -147,36 +147,36 @@ namespace Battle
 
             foreach (var card in toolbarCards)
             {
-                if (card.Rank.Value >= 10)
-                {
-                    card.Count.Value += 1;
-                    continue;
-                }
-
                 card.ExpCurrent.Value += expPerCard;
 
-                while (card.ExpCurrent.Value >= card.ExpToNextLevel.Value && card.Rank.Value < 10)
+                while (card.ExpCurrent.Value >= card.ExpToNextLevel.Value && card.Level.Value < CardModel.MaxLevel)
                 {
                     card.ExpCurrent.Value -= card.ExpToNextLevel.Value;
 
                     card.Level.Value += 1;
-                    card.Rank.Value  += 1;
+                    if (card.Rank.Value < CardModel.MaxRank)
+                        card.Rank.Value += 1;
 
-                    card.MaxHp.Value     += 1.1f;
-                    card.CurrentHp.Value += 1.1f;
-                    card.Attack.Value    += 1.1f;
-                    card.Evade.Value     += 1.1f;
-                    card.Block.Value     += 1.1f;
-                    card.BlockPower.Value+= 1.1f;
+                    card.MaxHp.Value      += 1.1f;
+                    card.CurrentHp.Value  += 1.1f;
+                    card.Attack.Value     += 1.1f;
+                    card.Evade.Value      += 1.1f;
+                    card.Block.Value      += 1.1f;
+                    card.BlockPower.Value += 1.1f;
 
                     card.ExpToNextLevel.Value = CalculateExpToNextLevel(card);
 
-                    if (card.Rank.Value >= 10)
+                    if (card.Level.Value >= CardModel.MaxLevel)
                     {
-                        card.ExpCurrent.Value = 0;
-                        card.Count.Value += 1;
+                        card.Level.Value = CardModel.MaxLevel;
+                        card.ExpCurrent.Value = card.ExpToNextLevel.Value;
                         break;
                     }
+                }
+
+                if (card.Level.Value >= CardModel.MaxLevel)
+                {
+                    card.ExpCurrent.Value = card.ExpToNextLevel.Value;
                 }
             }
         }

--- a/Assets/Scripts/Model/Card/CardModel.cs
+++ b/Assets/Scripts/Model/Card/CardModel.cs
@@ -5,6 +5,8 @@ namespace Model.Card
 {
     public class CardModel : IInventoryItem
     {
+        public const int MaxRank = 10;
+        public const int MaxLevel = 100;
         public int Id { get; set; }
         public string Title { get; set; }
         public ReactiveProperty<string> IconResourcesPath { get; } = new();

--- a/Assets/Scripts/Model/Inventory/InventoryModel.cs
+++ b/Assets/Scripts/Model/Inventory/InventoryModel.cs
@@ -80,7 +80,7 @@ namespace Model.Inventory
 
         public void AddOrStackItem(IInventoryItem domainItem)
         {
-            const int maxRank = 10;
+            const int maxRank = CardModel.MaxRank;
 
             if (domainItem is not CardModel newCard || newCard.Count.Value <= 0) 
                 return;

--- a/Assets/Scripts/Presentation/Boss/BossView.cs
+++ b/Assets/Scripts/Presentation/Boss/BossView.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections;
+using System.Globalization;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -12,11 +13,36 @@ namespace Presentation.Boss
         public TMP_Text HpOnSlider;
 
 
+        [SerializeField]
+        private float _sliderAnimDuration = 0.5f;
+
+        private Coroutine _sliderRoutine;
+
         public void SetSliderHp(float bossMaxHp, float bossCurrentHp)
         {
-            Slider.value = bossCurrentHp / bossMaxHp;
+            var target = bossCurrentHp / bossMaxHp;
 
             HpOnSlider.text = ((int)bossCurrentHp).ToString(CultureInfo.InvariantCulture);
+
+            if (_sliderRoutine != null)
+                StopCoroutine(_sliderRoutine);
+
+            _sliderRoutine = StartCoroutine(AnimateSlider(target));
+        }
+
+        private IEnumerator AnimateSlider(float target)
+        {
+            var start = Slider.value;
+            var time = 0f;
+
+            while (time < _sliderAnimDuration)
+            {
+                time += Time.deltaTime;
+                Slider.value = Mathf.Lerp(start, target, time / _sliderAnimDuration);
+                yield return null;
+            }
+
+            Slider.value = target;
         }
     }
 }

--- a/Assets/Scripts/Presentation/Card/CardPresenter.cs
+++ b/Assets/Scripts/Presentation/Card/CardPresenter.cs
@@ -16,9 +16,10 @@ namespace Presentation.Card
             UpdateSlider(cardModel.ExpCurrent, cardModel.ExpToNextLevel);
             _cardView.SetCount(cardModel.Count.Value);
             _cardView.SetRank(_cardModel.Rank.Value);
+            UpdateLevel(_cardModel.Level.Value);
 
             _cardModel.IconResourcesPath.OnValueChanged += UpdateIcon;
-            _cardModel.Level.OnValueChanged += _cardView.SetLevel;
+            _cardModel.Level.OnValueChanged += UpdateLevel;
 
             _cardModel.ExpCurrent.OnValueChanged += _cardView.SetSliderCurrentExp;
             _cardModel.ExpToNextLevel.OnValueChanged += _cardView.SetSliderNextExp;
@@ -44,9 +45,24 @@ namespace Presentation.Card
 
         private void UpdateExpText(float _)
         {
-            _cardView.SetExpText(
-                _cardModel.ExpCurrent.Value,
-                _cardModel.ExpToNextLevel.Value);
+            if (_cardModel.Level.Value >= CardModel.MaxLevel)
+            {
+                _cardView.SetMaxLevel();
+            }
+            else
+            {
+                _cardView.SetExpText(
+                    _cardModel.ExpCurrent.Value,
+                    _cardModel.ExpToNextLevel.Value);
+            }
+        }
+
+        private void UpdateLevel(int level)
+        {
+            if (level >= CardModel.MaxLevel)
+                _cardView.SetMaxLevel();
+            else
+                _cardView.SetLevel(level);
         }
     }
 }

--- a/Assets/Scripts/Presentation/Card/CardView.cs
+++ b/Assets/Scripts/Presentation/Card/CardView.cs
@@ -21,6 +21,12 @@ namespace Presentation.Card
 
         public Slider Slider;
 
+        public void SetMaxLevel()
+        {
+            Level.text = "max level";
+            Slider.value = Slider.maxValue;
+            ExpCurrent.text = "max level";
+        }
 
         public void SetLevel(int level)
         {

--- a/Assets/Scripts/Presentation/TotalStats/TotalCardStatsView.cs
+++ b/Assets/Scripts/Presentation/TotalStats/TotalCardStatsView.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections;
+using System.Globalization;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -28,13 +29,36 @@ namespace Presentation.TotalStats
         public Slider Slider;
         public TMP_Text HpOnSlider;
 
+        [SerializeField]
+        private float _sliderAnimDuration = 0.5f;
 
+        private Coroutine _sliderRoutine;
 
         public void SetSliderHp(float teamMaxHp, float teamCurrentHp)
         {
-            Slider.value = teamCurrentHp / teamMaxHp;
-        
+            var target = teamCurrentHp / teamMaxHp;
+
             HpOnSlider.text = teamCurrentHp.ToString(CultureInfo.InvariantCulture);
+
+            if (_sliderRoutine != null)
+                StopCoroutine(_sliderRoutine);
+
+            _sliderRoutine = StartCoroutine(AnimateSlider(target));
+        }
+
+        private IEnumerator AnimateSlider(float target)
+        {
+            var start = Slider.value;
+            var time = 0f;
+
+            while (time < _sliderAnimDuration)
+            {
+                time += Time.deltaTime;
+                Slider.value = Mathf.Lerp(start, target, time / _sliderAnimDuration);
+                yield return null;
+            }
+
+            Slider.value = target;
         }
 
 


### PR DESCRIPTION
## Summary
- add `MaxRank` and `MaxLevel` constants in `CardModel`
- use max rank in `InventoryModel`
- allow leveling to 100 and keep filling XP slider in `BattleScript`
- show `max level` in the UI via `CardView` and `CardPresenter`
- animate team and boss HP sliders to smoothly decrease

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6840493857d48329bec0168d8d48ba8a