### PR TITLE
Add card tooltip and smooth HP slider

### DIFF
--- a/Assets/Scripts/Presentation/Entity/EntityView.cs
+++ b/Assets/Scripts/Presentation/Entity/EntityView.cs
@@ -2,6 +2,7 @@
 using Model.InventoryCard;
 using Presentation.Card;
 using Presentation.Inventory;
+using Presentation.Tooltip;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -9,7 +10,7 @@ using UnityEngine.UI;
 
 namespace Presentation.Entity
 {
-    public class EntityView : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+    public class EntityView : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler, IPointerEnterHandler, IPointerExitHandler
     {
         private CardModel _cardModel;
         private InventoryPresenter _inventoryPresenter;
@@ -25,6 +26,8 @@ namespace Presentation.Entity
         private Transform _originalParent;
         private int _originalSiblingIndex;
 
+        private CardTooltipView _tooltip;
+
         public IInventoryItem DomainItem { get; private set; }
 
         private void Awake()
@@ -34,6 +37,8 @@ namespace Presentation.Entity
 
             _inventoryContainer = UIManager.I.InventoryContainer;
             _toolbarContainer   = UIManager.I.ToolbarContainer;
+
+            _tooltip = FindObjectOfType<CardTooltipView>(true);
         }
 
 
@@ -227,6 +232,18 @@ namespace Presentation.Entity
                 if (_cardModel != null)
                     _cardModel.CurrentHp.Value = _cardModel.MaxHp.Value;
             }
+        }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            if (_tooltip != null && _cardModel != null)
+                _tooltip.Show(_cardModel, eventData.position);
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            if (_tooltip != null)
+                _tooltip.Hide();
         }
     }
 }

--- a/Assets/Scripts/Presentation/Tooltip/CardTooltipView.cs
+++ b/Assets/Scripts/Presentation/Tooltip/CardTooltipView.cs
@@ -1,0 +1,52 @@
+using Model.Card;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Presentation.Tooltip
+{
+    /// <summary>
+    /// Displays detailed information about a card when hovered.
+    /// </summary>
+    public class CardTooltipView : MonoBehaviour
+    {
+        [SerializeField] private Image iconImage;
+        [SerializeField] private TMP_Text titleText;
+        [SerializeField] private TMP_Text levelText;
+        [SerializeField] private TMP_Text rankText;
+        [SerializeField] private TMP_Text hpText;
+        [SerializeField] private TMP_Text attackText;
+        [SerializeField] private TMP_Text critText;
+        [SerializeField] private TMP_Text critDmgText;
+        [SerializeField] private TMP_Text blockText;
+        [SerializeField] private TMP_Text blockPowerText;
+        [SerializeField] private TMP_Text evadeText;
+
+        public void Show(CardModel card, Vector3 position)
+        {
+            if (card == null) return;
+
+            if (iconImage != null && !string.IsNullOrEmpty(card.IconResourcesPath.Value))
+                iconImage.sprite = Resources.Load<Sprite>(card.IconResourcesPath.Value);
+
+            if (titleText != null) titleText.text = card.Title;
+            if (levelText != null) levelText.text = $"Lvl: {card.Level.Value}";
+            if (rankText != null) rankText.text = $"Rank: {card.Rank.Value}";
+            if (hpText != null) hpText.text = $"HP: {(int)card.CurrentHp.Value} / {(int)card.MaxHp.Value}";
+            if (attackText != null) attackText.text = $"Atk: {(int)card.Attack.Value}";
+            if (critText != null) critText.text = $"Crit: {(int)card.Crit.Value}%";
+            if (critDmgText != null) critDmgText.text = $"CritDmg: +{(int)card.CritDmg.Value}%";
+            if (blockText != null) blockText.text = $"Block: {(int)card.Block.Value}%";
+            if (blockPowerText != null) blockPowerText.text = $"BlockPower: {(int)card.BlockPower.Value}%";
+            if (evadeText != null) evadeText.text = $"Evade: {(int)card.Evade.Value}%";
+
+            transform.position = position;
+            gameObject.SetActive(true);
+        }
+
+        public void Hide()
+        {
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/Tooltip/CardTooltipView.cs.meta
+++ b/Assets/Scripts/Presentation/Tooltip/CardTooltipView.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3882c42bb2a14ab8aaaf304b28de3d63
+timeCreated: 1745010000

--- a/Assets/Scripts/Presentation/TotalStats/TotalCardStatsView.cs
+++ b/Assets/Scripts/Presentation/TotalStats/TotalCardStatsView.cs
@@ -30,7 +30,7 @@ namespace Presentation.TotalStats
         public TMP_Text HpOnSlider;
 
         [SerializeField]
-        private float _sliderAnimDuration = 0.5f;
+        private float _sliderAnimDuration = 1f;
 
         private Coroutine _sliderRoutine;
 


### PR DESCRIPTION
## Summary
- add `CardTooltipView` UI component
- enable showing tooltip on card hover
- animate team health slider for entire battle tick

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842f74ed0688329b10b862491d1d320