### PR TITLE
Fix health bar and battle logic

### DIFF
--- a/Assets/Scripts/Battle/BattleScript.cs
+++ b/Assets/Scripts/Battle/BattleScript.cs
@@ -62,6 +62,9 @@ namespace Battle
             if (_stats.Cards == null || _stats.Cards.Count == 0)
                 return;
 
+            if (_stats.Hp < _bossModel.Attack.Value)
+                return;
+
             var totalDamage = _stats.Cards.Sum(card => card.Attack.Value);
 
             // Critical attack case TODO:
@@ -122,11 +125,7 @@ namespace Battle
         
         private void OnEnemyWin()
         {
-            _zoneModel.CurrentZone.Value--;
-            if (_zoneModel.CurrentZone <= 0)
-            {
-                _zoneModel.CurrentZone.Value = 1;
-            }
+            _zoneModel.CurrentZone.Value = Mathf.Max(1, _zoneModel.CurrentZone.Value - 1);
             
             // Boss.Attack -= 100f;
 

--- a/Assets/Scripts/Presentation/TotalStats/TotalCardStatsView.cs
+++ b/Assets/Scripts/Presentation/TotalStats/TotalCardStatsView.cs
@@ -36,20 +36,21 @@ namespace Presentation.TotalStats
 
         public void SetSliderHp(float teamMaxHp, float teamCurrentHp)
         {
-            var target = teamCurrentHp / teamMaxHp;
-
-            HpOnSlider.text = teamCurrentHp.ToString(CultureInfo.InvariantCulture);
+            HpOnSlider.text = ((int)teamCurrentHp).ToString(CultureInfo.InvariantCulture);
 
             if (_sliderRoutine != null)
                 StopCoroutine(_sliderRoutine);
 
-            _sliderRoutine = StartCoroutine(AnimateSlider(target));
+            Slider.minValue = 0f;
+            Slider.maxValue = teamMaxHp;
+
+            _sliderRoutine = StartCoroutine(AnimateSlider(teamCurrentHp));
         }
 
         private IEnumerator AnimateSlider(float target)
         {
             var start = Slider.value;
-            var time = 0f;
+            var time  = 0f;
 
             while (time < _sliderAnimDuration)
             {

--- a/Assets/Scripts/Presentation/TotalStats/TotalToolbarStatsViewModel.cs
+++ b/Assets/Scripts/Presentation/TotalStats/TotalToolbarStatsViewModel.cs
@@ -45,9 +45,9 @@ namespace Presentation.TotalStats
         {
             foreach (var card in Cards)
             {
-                card.CurrentHp.Value = Mathf.Min(
-                card.CurrentHp.Value + card.HpRegeneration.Value * deltaTime,
-                card.MaxHp.Value);
+                var target = card.MaxHp.Value;
+                var step   = card.HpRegeneration.Value * deltaTime;
+                card.CurrentHp.Value = Mathf.MoveTowards(card.CurrentHp.Value, target, step);
             }
         }
     }


### PR DESCRIPTION
## Summary
- recalc team HP slider with proper max/min
- skip boss damage if team HP too low
- clamp zone drop to 1
- smoother regeneration using `MoveTowards`

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684fe211bd248329b5cc40c3c4eece5e