### PR TITLE
Display rank with roman numerals

### DIFF
--- a/Assets/Scripts/Presentation/Card/CardView.cs
+++ b/Assets/Scripts/Presentation/Card/CardView.cs
@@ -2,6 +2,7 @@
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using Utils;
 
 namespace Presentation.Card
 {
@@ -35,7 +36,7 @@ namespace Presentation.Card
 
         public void SetRank(int rank)
         {
-            Rank.text = "Rank: " + rank;
+            Rank.text = $"Rank: {RomanNumeralUtils.ToRoman(rank)}";
         }
 
         public void SetSliderCurrentExp(float currentExp)

--- a/Assets/Scripts/Presentation/Tooltip/CardTooltipView.cs
+++ b/Assets/Scripts/Presentation/Tooltip/CardTooltipView.cs
@@ -3,6 +3,7 @@ using Model.Card;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using Utils;
 
 namespace Presentation.Tooltip
 {
@@ -52,7 +53,7 @@ namespace Presentation.Tooltip
 
             if (titleText != null) titleText.text = card.Title;
             if (levelText != null) levelText.text = $"Lvl: {card.Level.Value}";
-            if (rankText != null) rankText.text = $"Rank: {card.Rank.Value}";
+            if (rankText != null) rankText.text = $"Rank: {RomanNumeralUtils.ToRoman(card.Rank.Value)}";
             if (hpText != null) hpText.text = $"HP: {(int)card.CurrentHp.Value} / {(int)card.MaxHp.Value}";
             if (attackText != null) attackText.text = $"Atk: {(int)card.Attack.Value}";
             if (critText != null) critText.text = $"Crit: {(int)card.Crit.Value}%";

--- a/Assets/Scripts/Utils/RomanNumeralUtils.cs
+++ b/Assets/Scripts/Utils/RomanNumeralUtils.cs
@@ -1,0 +1,27 @@
+using System.Text;
+
+namespace Utils
+{
+    public static class RomanNumeralUtils
+    {
+        public static string ToRoman(int number)
+        {
+            if (number <= 0)
+                return string.Empty;
+
+            var values = new[] {1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1};
+            var numerals = new[] {"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};
+
+            var result = new StringBuilder();
+            for (var i = 0; i < values.Length && number > 0; i++)
+            {
+                while (number >= values[i])
+                {
+                    result.Append(numerals[i]);
+                    number -= values[i];
+                }
+            }
+            return result.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/Utils/RomanNumeralUtils.cs.meta
+++ b/Assets/Scripts/Utils/RomanNumeralUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a06c8165aa6483eb803a53a2dc01de3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `RomanNumeralUtils` helper
- show roman numerals for rank in `CardView` and tooltip

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6863cfd414e48329a40d0ee763145ff6